### PR TITLE
Fix unused React imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import type { FC } from 'react';
 import { Outlet } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import './App.css';
 
-const App: React.FC = () => {
+const App: FC = () => {
   return (
     <>
       <Navbar />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const Footer: React.FC = () => (
+const Footer: FC = () => (
   <footer className="footer">
     <span>&copy; {new Date().getFullYear()} CodeBlackwell. All rights reserved.</span>
   </footer>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import type { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-const Navbar: React.FC = () => (
+const Navbar: FC = () => (
   <nav>
     <Link to="/" className="nav-link nav-home">Home</Link>
     <Link to="/about" className="nav-link">About</Link>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const About: React.FC = () => (
+const About: FC = () => (
   <div>
     <h1>About Me</h1>
     <p>This page will tell my story as a modern, future-focused engineer.</p>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const Contact: React.FC = () => (
+const Contact: FC = () => (
   <div>
     <h1>Contact</h1>
     <p>Reach out via this interactive form or find my social links here.</p>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const Home: React.FC = () => (
+const Home: FC = () => (
   <section className="hero">
     <div className="hero-inner">
       <h1 className="hero-title">Your Name</h1>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const Projects: React.FC = () => (
+const Projects: FC = () => (
   <div>
     <h1>Projects</h1>
     <p>Showcase of bleeding-edge work and advanced engineering projects will go here.</p>

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const Resume: React.FC = () => (
+const Resume: FC = () => (
   <div>
     <h1>Resume</h1>
     <p>Embed or link to my resume PDF here for easy access.</p>

--- a/src/pages/TechStack.tsx
+++ b/src/pages/TechStack.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import type { FC } from 'react';
 
-const TechStack: React.FC = () => (
+const TechStack: FC = () => (
   <div>
     <h1>Tech Stack</h1>
     <p>Interactive, visual representation of my advanced skills and tools will be featured here.</p>


### PR DESCRIPTION
## Summary
- fix unused React imports by using type-only `FC` imports

## Testing
- `tsc -p tsconfig.app.json` *(fails: Cannot find type definition file for 'react', 'react-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6857ca3d4708832fa6b18cf91ba62457